### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 - 2025-05-08
+### Removed
+- Removed the references for `auto-reconnect` in the dropcopy session to fix the following [issue](https://github.com/binance/binance-fix-connector-python/issues/2).
+
 ## 1.0.0 - 2025-03-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "binance_fix_connector"
-version = "1.0.0"
+version = "1.0.1"
 authors = [{name = "Binance"}]
 description = "This is a simple Python library that provides access to Binance Financial Information eXchange (FIX) SPOT messages using the FIX protocol."
 readme = "README.md"

--- a/src/binance_fix_connector/fix_connector.py
+++ b/src/binance_fix_connector/fix_connector.py
@@ -201,8 +201,6 @@ def create_drop_copy_session(
         fix_version=fix_version,
         heart_bt_int=heart_bt_int,
         socket_buffer_size=MAX_BUFFER_SIZE,
-        auto_reconnect=False,
-        auto_reconnect_attempts=3,
         reset_seq_num_flag="Y",
         encrypt_method=0,
         response_mode=response_mode,


### PR DESCRIPTION
### Removed
- Removed the references for `auto-reconnect` in the dropcopy session to fix the following [issue](https://github.com/binance/binance-fix-connector-python/issues/2).